### PR TITLE
1.8.1 - Fixing last-line, last-keyword highlighting and IP/port rule

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -176,11 +176,11 @@ def main():
     keywords_string = r"^\\s*({0})\\b".format("|".join(keywords))
     global_keywords_string = r"^\\s*({0})\\b".format("|".join(global_keywords))
     double_first_string = r"^\\s*({0})\\b".format("|".join(double_first))
-    double_second_string = r"\\s+({0})(?=\\s+)".format("|".join(double_second))
-    server_options_string = r"\\s+({0})(?=\\s+)".format("|".join(server_options))
-    bind_options_string = r"\\s+({0})(?=\\s+)".format("|".join(bind_options))
-    mailers_options_string = r"\\s+({0})(?=\\s+)".format("|".join(mailers_options))
-    peers_options_string = r"\\s+({0})(?=\\s+)".format("|".join(peers_options))
+    double_second_string = r"\\s+({0})(?=\\s+|$)".format("|".join(double_second))
+    server_options_string = r"\\s+({0})(?=\\s+|$)".format("|".join(server_options))
+    bind_options_string = r"\\s+({0})(?=\\s+|$)".format("|".join(bind_options))
+    mailers_options_string = r"\\s+({0})(?=\\s+|$)".format("|".join(mailers_options))
+    peers_options_string = r"\\s+({0})(?=\\s+|$)".format("|".join(peers_options))
 
     with open(args.template, "r") as f:
         template = f.read()

--- a/grammars/haproxy.cson
+++ b/grammars/haproxy.cson
@@ -28,15 +28,17 @@ patterns: [
     match: "#.+$"
     name: "comment.line.number-sign.haproxy-config"
   }
+  # IP address:port
+  {
+    match: "(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})?:\\d{1,5}"
+    name: "variable.parameter.ip-port.haproxy-config"
+  }
+  # Numbers
   {
      # this also inludes ip address-like dot separated instant with optional port
      # also optional letter supported, like '100s'
     match: "\\b[0-9]+([\\.:][0-9]+)*[a-z]?\\b"
     name: "constant.numeric.haproxy-config"
-  }
-  {
-    match: "(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})?:\\d{1,5}"
-    name: "variable.parameter.ip-port.haproxy-config"
   }
   # Keywords
   {
@@ -45,17 +47,17 @@ patterns: [
   }
   # Global keywords
   {
-    match: "^\\s*(51degrees-cache-size|51degrees-data-file|51degrees-property-name-list|51degrees-property-separator|ca-base|chroot|cpu-map|crt-base|daemon|debug|description|deviceatlas-json-file|deviceatlas-log-level|deviceatlas-properties-cookie|deviceatlas-separator|external-check|gid|group|hard-stop-after|log|log-send-hostname|log-tag|lua-load|max-spread-checks|maxcompcpuusage|maxcomprate|maxconn|maxconnrate|maxpipes|maxsessrate|maxsslconn|maxsslrate|maxzlibmem|nbproc|nbthread|node|noepoll|nogetaddrinfo|nokqueue|nopoll|noreuseport|nosplice|pidfile|presetenv|quiet|resetenv|server-state-base|server-state-file|setenv|spread-checks|ssl-default-bind-ciphers|ssl-default-bind-options|ssl-default-server-ciphers|ssl-default-server-options|ssl-dh-param-file|ssl-engine|ssl-mode-async|ssl-server-verify|stats|tune.buffers.limit|tune.buffers.reserve|tune.bufsize|tune.chksize|tune.comp.maxlevel|tune.h2.header-table-size|tune.h2.initial-window-size|tune.h2.max-concurrent-streams|tune.http.cookielen|tune.http.logurilen|tune.http.maxhdr|tune.idletimer|tune.lua.forced-yield|tune.lua.maxmem|tune.lua.service-timeout|tune.lua.session-timeout|tune.lua.task-timeout|tune.maxaccept|tune.maxpollevents|tune.maxrewrite|tune.pattern.cache-size|tune.pipesize|tune.rcvbuf.client|tune.rcvbuf.server|tune.recv_enough|tune.sndbuf.client|tune.sndbuf.server|tune.ssl.cachesize|tune.ssl.capture-cipherlist-size|tune.ssl.default-dh-param|tune.ssl.force-private-cache|tune.ssl.lifetime|tune.ssl.maxrecord|tune.ssl.ssl-ctx-cache-size|tune.vars.global-max-size|tune.vars.proc-max-size|tune.vars.reqres-max-size|tune.vars.sess-max-size|tune.vars.txn-max-size|tune.zlib.memlevel|tune.zlib.windowsize|uid|ulimit-n|unix-bind|unsetenv|user|wurfl-cache-size|wurfl-data-file|wurfl-engine-mode|wurfl-information-list|wurfl-information-list-separator|wurfl-useragent-priority)\\b"
+    match: "^\\s*(51degrees-cache-size|51degrees-data-file|51degrees-property-name-list|51degrees-property-separator|ca-base|chroot|cpu-map|crt-base|daemon|debug|description|deviceatlas-json-file|deviceatlas-log-level|deviceatlas-properties-cookie|deviceatlas-separator|external-check|gid|group|hard-stop-after|log|log-send-hostname|log-tag|lua-load|max-spread-checks|maxcompcpuusage|maxcomprate|maxconn|maxconnrate|maxpipes|maxsessrate|maxsslconn|maxsslrate|maxzlibmem|nbproc|nbthread|node|noepoll|nogetaddrinfo|nokqueue|nopoll|noreuseport|nosplice|pidfile|presetenv|quiet|resetenv|server-state-base|server-state-file|setenv|spread-checks|ssl-default-bind-ciphers|ssl-default-bind-ciphersuites|ssl-default-bind-options|ssl-default-server-ciphers|ssl-default-server-ciphersuites|ssl-default-server-options|ssl-dh-param-file|ssl-engine|ssl-mode-async|ssl-server-verify|stats|tune.buffers.limit|tune.buffers.reserve|tune.bufsize|tune.chksize|tune.comp.maxlevel|tune.h2.header-table-size|tune.h2.initial-window-size|tune.h2.max-concurrent-streams|tune.http.cookielen|tune.http.logurilen|tune.http.maxhdr|tune.idletimer|tune.lua.forced-yield|tune.lua.maxmem|tune.lua.service-timeout|tune.lua.session-timeout|tune.lua.task-timeout|tune.maxaccept|tune.maxpollevents|tune.maxrewrite|tune.pattern.cache-size|tune.pipesize|tune.rcvbuf.client|tune.rcvbuf.server|tune.recv_enough|tune.sndbuf.client|tune.sndbuf.server|tune.ssl.cachesize|tune.ssl.capture-cipherlist-size|tune.ssl.default-dh-param|tune.ssl.force-private-cache|tune.ssl.lifetime|tune.ssl.maxrecord|tune.ssl.ssl-ctx-cache-size|tune.vars.global-max-size|tune.vars.proc-max-size|tune.vars.reqres-max-size|tune.vars.sess-max-size|tune.vars.txn-max-size|tune.zlib.memlevel|tune.zlib.windowsize|uid|ulimit-n|unix-bind|unsetenv|user|wurfl-cache-size|wurfl-data-file|wurfl-engine-mode|wurfl-information-list|wurfl-information-list-separator|wurfl-useragent-priority)\\b"
     name: "keyword.other.no-validate-params.haproxy-config"
   }
   # Mailers
   {
-    match: "\\s+(mailer|timeout)(?=\\s+)"
+    match: "\\s+(mailer|timeout)(?=\\s+|$)"
     name: "keyword.other.no-validate-params.haproxy-config"
   }
   # Peers
   {
-    match: "\\s+(disabled|enable|peer)(?=\\s+)"
+    match: "\\s+(disabled|enable|peer)(?=\\s+|$)"
     name: "keyword.other.no-validate-params.haproxy-config"
   }
   # Keywords made up of two words - first word
@@ -65,17 +67,17 @@ patterns: [
   }
   # Keywords made up of two words - second word
   {
-    match: "\\s+(abortonclose|accept-invalid-http-request|accept-invalid-http-response|admin|allbackups|auth|capture|check|checkcache|client|client-fin|clitcpka|clitimeout|command|connect|connection|content|contimeout|contstats|cookie|disable-on-404|dontlog-normal|dontlognull|enable|expect|external-check|fail|forceclose|forwardfor|from|hide-version|http-buffer-request|http-ignore-probes|http-keep-alive|http-no-delay|http-pretend-keepalive|http-request|http-server-close|http-tunnel|http-use-proxy-header|http_proxy|httpchk|httpclose|httplog|independent-streams|inspect-delay|ldap-check|level|log-health-checks|log-separate-errors|logasap|mailers|match|myhostname|mysql-check|nolinger|on|originalto|path|persist|pgsql-check|prefer-last-server|queue|rdp-cookie|realm|redis-check|redispatch|refresh|scope|send|send-binary|send-state|server|server-fin|session|sessions|show-desc|show-legends|show-node|smtpchk|socket-stats|splice-auto|splice-request|splice-response|spop-check|srvtcpka|srvtimeout|ssl-hello-chk|store-request|store-response|tarpit|tcp-check|tcp-smart-accept|tcp-smart-connect|tcpka|tcplog|to|transparent|tunnel|uri)(?=\\s+)"
+    match: "\\s+(abortonclose|accept-invalid-http-request|accept-invalid-http-response|admin|allbackups|auth|capture|check|checkcache|client|client-fin|clitcpka|clitimeout|command|connect|connection|content|contimeout|contstats|cookie|disable-on-404|dontlog-normal|dontlognull|enable|expect|external-check|fail|forceclose|forwardfor|from|hide-version|http-buffer-request|http-ignore-probes|http-keep-alive|http-no-delay|http-pretend-keepalive|http-request|http-server-close|http-tunnel|http-use-proxy-header|http_proxy|httpchk|httpclose|httplog|independent-streams|inspect-delay|ldap-check|level|log-health-checks|log-separate-errors|logasap|mailers|match|myhostname|mysql-check|nolinger|on|originalto|path|persist|pgsql-check|prefer-last-server|queue|rdp-cookie|realm|redis-check|redispatch|refresh|scope|send|send-binary|send-state|server|server-fin|session|sessions|show-desc|show-legends|show-node|smtpchk|socket-stats|splice-auto|splice-request|splice-response|spop-check|srvtcpka|srvtimeout|ssl-hello-chk|store-request|store-response|tarpit|tcp-check|tcp-smart-accept|tcp-smart-connect|tcpka|tcplog|to|transparent|tunnel|uri)(?=\\s+|$)"
     name: "variable.language.reserved.haproxy-config"
   }
   # Bind options
   {
-    match: "\\s+(accept-netscaler-cip|accept-proxy|allow-0rtt|alpn|backlog|ca-file|ca-ignore-err|ca-sign-file|ca-sign-pass|ciphers|crl-file|crt|crt-ignore-err|crt-list|curves|defer-accept|ecdhe|expose-fd|force-sslv3|force-tlsv10|force-tlsv11|force-tlsv12|force-tlsv13|generate-certificates|gid|group|id|interface|level|maxconn|mode|mss|name|namespace|nice|no-ca-names|no-sslv3|no-tls-tickets|no-tlsv10|no-tlsv11|no-tlsv12|no-tlsv13|npn|prefer-client-ciphers|process|severity-output|ssl|ssl-max-ver|ssl-min-ver|strict-sni|tcp-ut|tfo|tls-ticket-keys|transparent|uid|user|v4v6|v6only|verify)(?=\\s+)"
+    match: "\\s+(accept-netscaler-cip|accept-proxy|allow-0rtt|alpn|backlog|ca-file|ca-ignore-err|ca-sign-file|ca-sign-pass|ciphers|ciphersuites|crl-file|crt|crt-ignore-err|crt-list|curves|defer-accept|ecdhe|expose-fd|force-sslv3|force-tlsv10|force-tlsv11|force-tlsv12|force-tlsv13|generate-certificates|gid|group|id|interface|level|maxconn|mode|mss|name|namespace|nice|no-ca-names|no-sslv3|no-tls-tickets|no-tlsv10|no-tlsv11|no-tlsv12|no-tlsv13|npn|prefer-client-ciphers|process|severity-output|ssl|ssl-max-ver|ssl-min-ver|strict-sni|tcp-ut|tfo|tls-ticket-keys|transparent|uid|user|v4v6|v6only|verify)(?=\\s+|$)"
     name: "variable.language.reserved.haproxy-config"
   }
   # Server options
   {
-    match: "\\s+(addr|agent-addr|agent-check|agent-inter|agent-port|agent-send|backup|ca-file|check|check-send-proxy|check-sni|check-ssl|ciphers|cookie|crl-file|crt|disabled|downinter|enabled|error-limit|fall|fastinter|force-sslv3|force-tlsv10|force-tlsv11|force-tlsv12|force-tlsv13|id|init-addr|inter|maxconn|maxqueue|minconn|namespace|no-agent-check|no-backup|no-check|no-check-ssl|no-send-proxy|no-send-proxy-v2|no-send-proxy-v2-ssl|no-send-proxy-v2-ssl-cn|no-ssl|no-ssl-reuse|no-sslv3|no-tls-tickets|no-tlsv10|no-tlsv11|no-tlsv12|no-tlsv13|no-verifyhost|non-stick|observe|on-error|on-marked-down|on-marked-up|port|redir|resolve-net|resolve-opts|resolve-prefer|resolvers|rise|send-proxy|send-proxy-v2|send-proxy-v2-ssl|send-proxy-v2-ssl-cn|slowstart|sni|source|ssl|ssl-max-ver|ssl-min-ver|ssl-reuse|stick|tcp-ut|tls-tickets|track|verify|verifyhost|weight)(?=\\s+)"
+    match: "\\s+(addr|agent-addr|agent-check|agent-inter|agent-port|agent-send|backup|ca-file|check|check-send-proxy|check-sni|check-ssl|ciphers|ciphersuites|cookie|crl-file|crt|disabled|downinter|enabled|error-limit|fall|fastinter|force-sslv3|force-tlsv10|force-tlsv11|force-tlsv12|force-tlsv13|id|init-addr|inter|maxconn|maxqueue|minconn|namespace|no-agent-check|no-backup|no-check|no-check-ssl|no-send-proxy|no-send-proxy-v2|no-send-proxy-v2-ssl|no-send-proxy-v2-ssl-cn|no-ssl|no-ssl-reuse|no-sslv3|no-tls-tickets|no-tlsv10|no-tlsv11|no-tlsv12|no-tlsv13|no-verifyhost|non-stick|observe|on-error|on-marked-down|on-marked-up|port|redir|resolve-net|resolve-opts|resolve-prefer|resolvers|rise|send-proxy|send-proxy-v2|send-proxy-v2-ssl|send-proxy-v2-ssl-cn|slowstart|sni|source|ssl|ssl-max-ver|ssl-min-ver|ssl-reuse|stick|tcp-ut|tls-tickets|track|verify|verifyhost|weight)(?=\\s+|$)"
     name: "variable.language.reserved.haproxy-config"
   }
   # Stick-table options

--- a/haproxy.cson.template
+++ b/haproxy.cson.template
@@ -28,15 +28,17 @@ patterns: [
     match: "#.+$"
     name: "comment.line.number-sign.haproxy-config"
   }
+  # IP address:port
+  {
+    match: "(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})?:\\d{1,5}"
+    name: "variable.parameter.ip-port.haproxy-config"
+  }
+  # Numbers
   {
      # this also inludes ip address-like dot separated instant with optional port
      # also optional letter supported, like '100s'
     match: "\\b[0-9]+([\\.:][0-9]+)*[a-z]?\\b"
     name: "constant.numeric.haproxy-config"
-  }
-  {
-    match: "(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})?:\\d{1,5}"
-    name: "variable.parameter.ip-port.haproxy-config"
   }
   # Keywords
   {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-haproxy",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Syntax support for HAProxy configuration files",
   "keywords": [],
   "repository": "https://github.com/abulimov/atom-language-haproxy",


### PR DESCRIPTION
Fixed keywords that are at the end of line, but also at the end of the file/code snippet, so without a newline after them -- so that they are correctly highlighted. Otherwise, the very last keyword on the last line in the file isn't highlighted. Instead of only looking for \s+ to follow the keyword, now also looking for end of line, $.

Also, swapped the "IP address/port" and "Number" patterns because Number was too greedy. IP addresses were not highlighted with the variable.parameter.ip-port.haproxy-config rule, but instead were getting the constant.numeric.haproxy-config rule applied to them.

Test:

```
defaults
    timeout connect 10s
    timeout client 30s
    timeout server 30s
    log global
    mode http
    option httplog
    maxconn 3000

frontend fe_main
  bind :80
  default_backend be_cart

backend be_cart
    server s1 10.0.0.3:80

backend mobile_api
    balance roundrobin 
    server s1 10.0.0.3:80 maxconn 100
    server s2 10.0.0.4:80 maxconn 100
```